### PR TITLE
Fix the bug with confidence scales

### DIFF
--- a/public/js/test.js
+++ b/public/js/test.js
@@ -362,7 +362,7 @@ function  buildTests (type)
 	for(let j =0; j < questions.length; j++)
 	{
 		var confidenceBar = "rightCol"+j+"";
-		document.getElementById(confidenceBar).onclick = function(){
+		document.getElementById(confidenceBar).onmousedown = function(){
 			confidencetouched[j] = true;
 		}
 	}


### PR DESCRIPTION
Changing the event from onclick to onmousedown makes sure that the test confidence sliders register the change

